### PR TITLE
feat : 채팅 메시지 visible 분기 / match 생성 당시의 일시, 장소를 표시 / 산책 메이트 요청 송신측 메시지 타입 추가

### DIFF
--- a/app/src/main/java/com/petpal/mungmate/model/ChatRoom.kt
+++ b/app/src/main/java/com/petpal/mungmate/model/ChatRoom.kt
@@ -6,6 +6,7 @@ import com.google.firebase.Timestamp
 
 // 채팅방
 data class ChatRoom (
+    var id: String,
     val senderId: String,
     val receiverId: String,
     val lastMessage: String?,
@@ -14,6 +15,45 @@ data class ChatRoom (
     val receiverIsExit: Boolean,
     val senderUnReadCount: Long?,
     val receiverUnReadCount: Long?
-) {
-    constructor() : this("", "", null, null, false, false, null, null)
+):Parcelable {
+    constructor(parcel: Parcel) : this(
+        parcel.readString().toString(),
+        parcel.readString().toString(),
+        parcel.readString().toString(),
+        parcel.readString(),
+        parcel.readParcelable(Timestamp::class.java.classLoader),
+        parcel.readByte() != 0.toByte(),
+        parcel.readByte() != 0.toByte(),
+        parcel.readValue(Long::class.java.classLoader) as? Long,
+        parcel.readValue(Long::class.java.classLoader) as? Long
+    ) {
+    }
+
+    constructor() : this("", "", "", null, null, false, false, null, null)
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeString(id)
+        parcel.writeString(senderId)
+        parcel.writeString(receiverId)
+        parcel.writeString(lastMessage)
+        parcel.writeParcelable(lastMessageTime, flags)
+        parcel.writeByte(if (senderIsExit) 1 else 0)
+        parcel.writeByte(if (receiverIsExit) 1 else 0)
+        parcel.writeValue(senderUnReadCount)
+        parcel.writeValue(receiverUnReadCount)
+    }
+
+    override fun describeContents(): Int {
+        return 0
+    }
+
+    companion object CREATOR : Parcelable.Creator<ChatRoom> {
+        override fun createFromParcel(parcel: Parcel): ChatRoom {
+            return ChatRoom(parcel)
+        }
+
+        override fun newArray(size: Int): Array<ChatRoom?> {
+            return arrayOfNulls(size)
+        }
+    }
 }

--- a/app/src/main/java/com/petpal/mungmate/model/Message.kt
+++ b/app/src/main/java/com/petpal/mungmate/model/Message.kt
@@ -10,18 +10,20 @@ data class Message(
     val timestamp: Timestamp,
     val receiverIsRead: Boolean,
     val type: Int,
-    val visible: Int
+    val visible: Int,
+    val matchId: String? = null
 ) {
-    constructor(): this("", "", "", Timestamp.now(), true, MessageType.TEXT.code, MessageVisibility.ALL.code)
+    constructor(): this("", "", "", Timestamp.now(), true, MessageType.TEXT.code, MessageVisibility.ALL.code, null)
 }
 
 // 각기 다른 뷰를 가지는 메시지 유형
 enum class MessageType(val code: Int) {
-    TEXT(0),                // 채팅 텍스트
-    DATE(1),                // 날짜
-    WALK_MATE_REQUEST(2),   // 산책 메이트 요청
-    WALK_MATE_ACCEPT(3),    // 산책 메이트 수락
-    WALK_MATE_REJECT(4)     // 산책 메이트 거절
+    TEXT(0),                        // 채팅 텍스트
+    DATE(1),                        // 날짜
+    WALK_MATE_REQUEST_SEND(2),      // 산책 메이트 요청 전송
+    WALK_MATE_REQUEST_RECEIVE(3),   // 산책 메이트 요청 수신
+    WALK_MATE_ACCEPT(4),            // 산책 메이트 수락
+    WALK_MATE_REJECT(5),            // 산책 메이트 거절
 }
 
 // 메시지 표시 여부 : 해당 메시지를 볼 수 있는 사용자

--- a/app/src/main/java/com/petpal/mungmate/ui/chat/ChatRepository.kt
+++ b/app/src/main/java/com/petpal/mungmate/ui/chat/ChatRepository.kt
@@ -321,16 +321,31 @@ class ChatRepository {
         }
     }
 
-    suspend fun updateFieldInMessageDocument(messageId: String, fieldName: String, updateValue: Any) {
-        val messageDocRef = db.collection(MESSAGES_NAME).document(messageId)
+    suspend fun updateFieldInMessageDocument(chatRoomId: String, messageId: String, fieldName: String, updateValue: Any) {
+        val messageDocRef = db.collection(CHAT_ROOMS_NAME)
+            .document(chatRoomId)
+            .collection(MESSAGES_NAME)
+            .document(messageId)
         val updateData = hashMapOf<String, Any>()
         updateData[fieldName] = updateValue
 
         try {
+            val snapshot = messageDocRef.get().await()
+            if (snapshot.exists()) {
+                val existingData = snapshot.data
+                Log.d(TAG, "Existing Data : $existingData")
+            }
+
             messageDocRef.update(updateData).await()
+
+            val updatedSnapshot = messageDocRef.get().await()
+            if (updatedSnapshot.exists()) {
+                val updatedData = updatedSnapshot.data
+                Log.d(TAG, "Updated Data : $updatedData")
+            }
         } catch (e: Exception) {
             e.printStackTrace()
+            Log.d(TAG, "Error updating field in message document: ${e.message}")
         }
-
     }
 }

--- a/app/src/main/java/com/petpal/mungmate/ui/chat/ChatRoomViewModel.kt
+++ b/app/src/main/java/com/petpal/mungmate/ui/chat/ChatRoomViewModel.kt
@@ -175,7 +175,7 @@ class ChatRoomViewModel: ViewModel() {
         viewModelScope.launch(Dispatchers.IO) {
             chatRepository.updateFieldInMessageDocument(messageId, "visible", MessageVisibility.NONE.code)
         }
-
+        
     }
 }
 

--- a/app/src/main/java/com/petpal/mungmate/ui/chat/ChatRoomViewModel.kt
+++ b/app/src/main/java/com/petpal/mungmate/ui/chat/ChatRoomViewModel.kt
@@ -127,9 +127,9 @@ class ChatRoomViewModel: ViewModel() {
     }
 
     // 매칭 데이터 업데이트
-    fun updateFieldInMatchDocument(matchKey: String, fieldName: String, updatedValue: Any) {
+    fun updateFieldInMatchDocument(matchId: String, fieldName: String, updatedValue: Any) {
         viewModelScope.launch(Dispatchers.IO) {
-            chatRepository.updateFieldInMatchDocument(matchKey, fieldName, updatedValue)
+            chatRepository.updateFieldInMatchDocument(matchId, fieldName, updatedValue)
         }
     }
 
@@ -171,9 +171,9 @@ class ChatRoomViewModel: ViewModel() {
         }
     }
 
-    fun hideMessage(messageId: String) {
+    fun hideMessage(chatRoomId: String, messageId: String) {
         viewModelScope.launch(Dispatchers.IO) {
-            chatRepository.updateFieldInMessageDocument(messageId, "visible", MessageVisibility.NONE.code)
+            chatRepository.updateFieldInMessageDocument(chatRoomId, messageId, "visible", MessageVisibility.NONE.code)
         }
         
     }

--- a/app/src/main/java/com/petpal/mungmate/ui/chat/MessageAdapter.kt
+++ b/app/src/main/java/com/petpal/mungmate/ui/chat/MessageAdapter.kt
@@ -221,18 +221,15 @@ class MessageAdapter(private val chatRoomViewModel: ChatRoomViewModel): Recycler
                     textViewRequestPlace.text = matchPlace
                 }
 
+                val chatRoomId = chatRoomViewModel.currentChatRoom.value?.id!!
                 val matchId = message.matchId!!
 
                 buttonAccept.setOnClickListener {
-                    // 하나의 match에 대해 수락, 거절은 한 번만 선택 가능
-                    buttonAccept.isEnabled = false
-                    buttonReject.isEnabled = false
-                    
                     // 매칭 상태 변경 -> 수락
                     chatRoomViewModel.updateFieldInMatchDocument(matchId, "status", MatchStatus.ACCEPTED.code)
 
                     // 산책 메이트 요청 메시지 숨기기
-                    chatRoomViewModel.hideMessage(message.id)
+                    chatRoomViewModel.hideMessage(chatRoomId, message.id)
 
                     // 산책 메이트 수락 메시지 전송
                     val message = Message(
@@ -249,14 +246,11 @@ class MessageAdapter(private val chatRoomViewModel: ChatRoomViewModel): Recycler
                 }
 
                 buttonReject.setOnClickListener {
-                    buttonAccept.isEnabled = false
-                    buttonReject.isEnabled = false
-
                     // 매칭 상태 변경 -> 거절
                     chatRoomViewModel.updateFieldInMatchDocument(matchId, "status", MatchStatus.REJECTED.code)
 
                     // 산책 메이트 요청 메시지 숨기기
-                    chatRoomViewModel.hideMessage(message.id)
+                    chatRoomViewModel.hideMessage(chatRoomId, message.id)
                     
                     // 산책 메이트 거절 메시지 전송
                     val message = Message(

--- a/app/src/main/java/com/petpal/mungmate/ui/chat/WalkMateRequestFragment.kt
+++ b/app/src/main/java/com/petpal/mungmate/ui/chat/WalkMateRequestFragment.kt
@@ -274,8 +274,7 @@ class WalkMateRequestFragment : Fragment() {
         )
 
         chatRoomViewModel.sendMessage(currentChatRoom.id, receiverMessage)
-
-        Snackbar.make(requireView(), "산책 메이트 요청 메시지를 전송했습니다.", Snackbar.LENGTH_SHORT).show()
+        // Snackbar.make(requireView(), "산책 메이트 요청 메시지를 전송했습니다.", Snackbar.LENGTH_SHORT).show()
 
         findNavController().popBackStack()
     }

--- a/app/src/main/res/layout/row_chat_walk_mate_request.xml
+++ b/app/src/main/res/layout/row_chat_walk_mate_request.xml
@@ -72,7 +72,6 @@
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="8dp"
                 android:layout_weight="1"
-                android:enabled="false"
                 android:text="수락" />
 
             <Button
@@ -80,7 +79,6 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:enabled="false"
                 android:text="거절" />
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/row_chat_walk_mate_request_receive.xml
+++ b/app/src/main/res/layout/row_chat_walk_mate_request_receive.xml
@@ -44,7 +44,7 @@
             android:orientation="vertical">
 
             <TextView
-                android:id="@+id/text_view_request_date_time"
+                android:id="@+id/textViewRequestDateTime"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"

--- a/app/src/main/res/layout/row_chat_walk_mate_request_send.xml
+++ b/app/src/main/res/layout/row_chat_walk_mate_request_send.xml
@@ -64,8 +64,9 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
                 android:layout_weight="1"
-                android:text="상대가 요청을 수락하면 산책 매칭이 성사됩니다."
-                android:textColor="@color/md_theme_dark_onTertiary" />
+                android:text="★ 상대가 요청을 수락하면 산책 매칭이 성사됩니다."
+                android:textColor="@color/md_theme_dark_secondaryContainer" />
+
         </LinearLayout>
 
     </LinearLayout>

--- a/app/src/main/res/layout/row_chat_walk_mate_request_send.xml
+++ b/app/src/main/res/layout/row_chat_walk_mate_request_send.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/Widget.Material3.CardView.Elevated"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    app:cardUseCompatPadding="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <de.hdodenhof.circleimageview.CircleImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginEnd="8dp"
+                android:adjustViewBounds="false"
+                android:background="@android:color/transparent"
+                android:scaleType="centerCrop"
+                android:src="@drawable/event_24px"
+                app:civ_border_overlay="true" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="산책 메이트 요청 완료"
+                android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+                android:textStyle="bold" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/textViewRequestDateTime"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_weight="1"
+                android:text="일시 : 9월 5일 (화) 오후 6:00" />
+
+            <TextView
+                android:id="@+id/textViewRequestPlace"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_weight="1"
+                android:text="장소 : 강아지 공원 앞" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_weight="1"
+                android:text="상대가 요청을 수락하면 산책 매칭이 성사됩니다."
+                android:textColor="@color/md_theme_dark_onTertiary" />
+        </LinearLayout>
+
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/navigation/chat.xml
+++ b/app/src/main/res/navigation/chat.xml
@@ -11,14 +11,11 @@
         android:label="산책 메이트 요청"
         tools:layout="@layout/fragment_walk_mate_request" >
         <argument
-            android:name="senderId"
-            app:argType="string" />
-        <argument
             android:name="receiverId"
             app:argType="string" />
         <argument
-            android:name="chatRoomId"
-            app:argType="string" />
+            android:name="chatRoom"
+            app:argType="com.petpal.mungmate.model.ChatRoom" />
     </fragment>
     <fragment
         android:id="@+id/chatRoomFragment"


### PR DESCRIPTION
## PR Type
어떤 것에 대한 PR인지?

<!-- 아래 괄호 사이"x"를 입력해서 체크할 수 있습니당. -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (프로젝트 설정)
- [ ] Documentation content changes
- [ ] Other... 


## PR Checklist
PR하기 전에 아래 조건 충족했는지 확인!

- [x] 커밋 메세지 포맷에 맞게 작성했나요?
- [ ] (bug fixes / features의 경우) docs을 첨부/수정 했나요?


## 변경사항
- Message 클래스 변수 추가
  - 연관된 matchId
- 채팅 메시지 필터링
  - 전체, 나에게 보일 메시지만 표시 (MessageVisibility)
- 하나의 매칭에 대해 수락, 거절 한 번만 누르고 요청 메시지 숨기기
- 산책 메이트 요청 후 Snackbar가 메시지 입력칸 가리는 문제 해결
- 산책 메이트 요청 송신측도 자신이 설정한 일시, 장소 확인할 수 있도록 ViewHolder / Message Type 추가  + 안내문구
![image](https://github.com/APPSCHOOL2-Android/FinalProject-PetPal/assets/86085387/20ff5f7c-5ea9-4de8-8dc7-769e195cc8ac)
- 차후 매칭 정보 수정 대비해서 산책 메이트 요청 메시지에 matches 컬렉션에서 데이터 읽어오던 기존 방식에서 수락 당시의 일시, 장소 텍스트로 기록해두고 표시하는 식으로 변경

## 스크린샷
### 산책 요청 -> 수락
https://github.com/APPSCHOOL2-Android/FinalProject-PetPal/assets/86085387/0dc3d544-601d-4e83-bfa1-91772b9ee329

### 산책 요청 -> 거절
https://github.com/APPSCHOOL2-Android/FinalProject-PetPal/assets/86085387/335d0913-5334-40ac-ac6f-50f6ad428552

## Issue number and link
<!-- issue 링크 해주면 됩니다~-->
#147 

## 리뷰어들에게 전할 말

## 비고
